### PR TITLE
Add: 投稿一覧画面のソート機能追加

### DIFF
--- a/sns/urls.py
+++ b/sns/urls.py
@@ -4,6 +4,7 @@ from . import views
 app_name = 'sns'
 urlpatterns = [
     path('', views.IndexView.as_view(), name='index'),
+    path('reverse/', views.IndexReverseView.as_view(), name='index_reverse'),
     path('detail/<int:pk>/', views.PostDetailView.as_view(), name='post_detail'),
     path('category/<str:category_slug>/',
          views.CategoryPostView.as_view(), name='category_post'),

--- a/sns/views.py
+++ b/sns/views.py
@@ -12,9 +12,20 @@ class IndexView(generic.ListView):
     template_name = 'sns/index.html'
 
     # def get_queryset(self):
-    #     object_list = super().get_queryset()
-    #     print(object_list)
-    #     return Post.objects.filter(author='admin')
+    #     return Post.objects.order_by('published_at')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['category_list'] = Category.objects.all()
+        return context
+
+
+class IndexReverseView(generic.ListView):
+    model = Post
+    template_name = 'sns/index.html'
+
+    def get_queryset(self):
+        return Post.objects.order_by('published_at')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/sns/category_post.html
+++ b/templates/sns/category_post.html
@@ -2,6 +2,11 @@
 
 {% block content %}
     <h4>「{{ category.name }}」の投稿一覧</h4>
+    <p>
+        <a href="{% url 'sns:index' %}">新しい順</a>
+        <a href="{% url 'sns:index_reverse' %}">古い順</a>
+    </p>
+
     <div class="uk-grid-small uk-child-width-1-3@m" uk-grid>
     {% for post in object_list %}
         <div>

--- a/templates/sns/index.html
+++ b/templates/sns/index.html
@@ -2,6 +2,10 @@
 
 {% block content %}
     <h4>新着投稿一覧</h4>
+    <p>
+        <a href="{% url 'sns:index' %}">新しい順</a>
+        <a href="{% url 'sns:index_reverse' %}">古い順</a>
+    </p>
     <div class="uk-grid-small uk-child-width-1-3@m" uk-grid>
     {% for post in object_list %}
         <div>


### PR DESCRIPTION
投稿一覧画面を新しい順、古い順でソートできる機能を追加しました。
しかし、カテゴリー別の一覧画面からはまだ動作しません。
よろしくお願いします。